### PR TITLE
Use the public endpoint for the package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/css/mustard-ui.min.css",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kylelogue/mustard-ui.git"
+    "url": "https://github.com/kylelogue/mustard-ui.git"
   },
   "keywords": [
     "css",


### PR DESCRIPTION
When using the URL in the current `package.json`, this happens:

```
ryloth:/tmp<>$ git clone git+https://github.com/kylelogue/mustard-ui.git
Cloning into 'mustard-ui'...
fatal: Unable to find remote helper for 'git+https'
```

But the main public URL works - this is the one GitHub shows to non-logged in users:

```
ryloth:/tmp<>$ git clone https://github.com/kylelogue/mustard-ui
Cloning into 'mustard-ui'...
remote: Counting objects: 276, done.
remote: Compressing objects: 100% (134/134), done.
remote: Total 276 (delta 135), reused 238 (delta 107), pack-reused 0
Receiving objects: 100% (276/276), 127.51 KiB | 0 bytes/s, done.
Resolving deltas: 100% (135/135), done.
Checking connectivity... done.
```

I'm not sure if this is what you want, but it seemed to work for me. :)