### PR TITLE
Added border radius to .menu children

### DIFF
--- a/src/scss/components/menus.scss
+++ b/src/scss/components/menus.scss
@@ -26,5 +26,13 @@ $menu-hover-color: $color-gray-50;
                 background: $menu-hover-color;
             }
         }
+        
+        &:first-child a {
+            border-radius: 5px 5px 0 0;
+        }
+
+        &:last-child a {
+            border-radius: 0 0 5px 5px;
+        }
     }
 }


### PR DESCRIPTION
when a background is added to a:hover the border-radius is lost. Other option would be to set overflow hidden on .menu but this causes the border-radius to be lost briefly on some browsers