### PR TITLE
Straight colors

### DIFF
--- a/src/scss/vars/colors.scss
+++ b/src/scss/vars/colors.scss
@@ -14,6 +14,7 @@ $color-gray-600: #757575 !default;
 $color-gray-700: #616161 !default;
 $color-gray-800: #424242 !default;
 $color-gray-900: #212121 !default;
+$color-gray: $color-gray-600 !default;
 
 $color-blue-gray-50: #eceff1 !default;
 $color-blue-gray-100: #cfd8dc !default;


### PR DESCRIPTION
Define the straight colour constants without gradient like
$color-blue
$color-indigo
etc...

In this way, we can centre my design into Mustard balanced colours scheme or mix others... 
I'll call this the Mustard-Palette